### PR TITLE
Build micro and init variants of the container images

### DIFF
--- a/.github/workflows/build-2nd-layer.yml
+++ b/.github/workflows/build-2nd-layer.yml
@@ -1,0 +1,65 @@
+---
+name: Build images 2nd layer images
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * 0"
+
+jobs:
+  run_image_builds:
+    strategy:
+      matrix:
+        version:
+          - major: 8
+            arch: 'amd64, arm64'
+          - major: 9
+            arch: 'amd64, arm64, ppc64le, s390x'
+        type:
+          - micro
+          - init
+        registry:
+          - domain: docker.io
+            account: rockylinux
+            secret: DOCKER
+          - domain: quay.io
+            account: rockylinux
+            secret: QUAY
+    runs-on: ubuntu-latest
+    name: Build and push images
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Setup Registry login
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets[format('{0}_USERNAME', matrix.registry.secret)] }}
+          password: ${{ secrets[format('{0}_TOKEN', matrix.registry.secret)] }}
+          registry: ${{ matrix.registry.domain }}
+      
+      - name: Build image
+        uses: redhat-actions/buildah-build@v2
+        id: build-image
+        with:
+          archs: ${{ matrix.version.arch }}
+          build-args: |
+            ImageVersion=${{ matrix.version.major }}
+          containerfiles: |
+            ./Containerfile-${{ matrix.type }}
+          labels: |
+            name=rockylinux
+            version=${{ matrix.version.major }}-ubi-${{ matrix.type }}
+          tags: ${{ matrix.registry.domain }}/${{ matrix.registry.account }}/rockylinux:${{ matrix.version.major }}-ubi-${{ matrix.type }}
+
+      - name: Push image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+---
+name: CI build for 2nd layer images
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  IMAGE_REGISTRY: docker.io
+  IMAGE_ACCOUNT: rockylinux
+
+jobs:
+  run_image_builds:
+    strategy:
+      matrix:
+        version:
+          - major: 8
+            arch: 'amd64, arm64'
+          - major: 9
+            arch: 'amd64, arm64, ppc64le, s390x'
+        type:
+          - micro
+          - init
+    runs-on: ubuntu-latest
+    name: Test the image build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build image
+        uses: redhat-actions/buildah-build@v2
+        id: build-image
+        with:
+          archs: ${{ matrix.version.arch }}
+          build-args: |
+            ImageVersion=${{ matrix.version.major }}
+          containerfiles: |
+            ./Containerfile-${{ matrix.type }}
+          labels: |
+            name=rockylinux
+            version=${{ matrix.version.major }}-ubi-${{ matrix.type }}
+          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rockylinux:${{ matrix.version.major }}-ubi-${{ matrix.type }}

--- a/Containerfile-init
+++ b/Containerfile-init
@@ -1,0 +1,19 @@
+ARG ImageVersion
+
+FROM rockylinux/rockylinux:$ImageVersion-ubi
+LABEL summary="Rocky Linux UBI init image" \
+      description="This image is designed to run an init system as PID 1 for running multi-services inside a container." \
+      usage="Do not use directly. Use as a base image for daemons. Install chosen packages and 'systemctl enable' them." \
+      maintainer="Magauer Lukas <lukas@magauer.eu>"
+
+CMD ["/sbin/init"]
+
+STOPSIGNAL SIGRTMIN+3
+
+#TODO: this is a workaround until the ubi image has systemd in it again
+RUN dnf -y install systemd
+
+#mask systemd-machine-id-commit.service - partial fix for https://bugzilla.redhat.com/show_bug.cgi?id=1472439
+RUN systemctl mask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount systemd-logind.service getty.target console-getty.service systemd-udev-trigger.service systemd-udevd.service systemd-random-seed.service systemd-machine-id-commit.service
+
+RUN dnf -y install procps-ng && dnf clean all; rm -rf /var/cache /var/log/dnf* /var/log/yum.*

--- a/Containerfile-micro
+++ b/Containerfile-micro
@@ -1,0 +1,15 @@
+ARG ImageVersion
+
+FROM rockylinux/rockylinux:$ImageVersion-ubi as ubi-micro-build
+ARG ImageVersion
+RUN yum install --installroot /mnt/rootfs coreutils-single glibc-minimal-langpack --releasever $ImageVersion --setopt install_weak_deps=false --nodocs -y && yum --installroot /mnt/rootfs clean all
+RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
+
+FROM scratch
+LABEL summary="Rocky Linux UBI micro image" \
+      description="Very small image which doesn't install the package manager." \
+      maintainer="Magauer Lukas <lukas@magauer.eu>"
+
+COPY --from=ubi-micro-build /mnt/rootfs/ /
+COPY --from=ubi-micro-build /etc/yum.repos.d/* /etc/yum.repos.d/
+CMD /bin/sh


### PR DESCRIPTION
There are still some TODOs left:

- Make sure that the UBI images are built very similar to the upstream images, and then removing the systemd install in the init container, related PRs are available [here](https://git.resf.org/sig_core/kickstarts/pulls/7) and [here](https://git.resf.org/sig_core/kickstarts/pulls/8)

If any changes/improvements are wanted, sure I can take them in account!
Testbuilds are available here: https://quay.io/repository/lumarel/rockylinux?tab=tags