### PR TITLE
Rewrite metadata to docker format

### DIFF
--- a/.github/workflows/build-2nd-layer.yml
+++ b/.github/workflows/build-2nd-layer.yml
@@ -56,6 +56,7 @@ jobs:
           labels: |
             name=rockylinux
             version=${{ matrix.version.major }}-ubi-${{ matrix.type }}
+          oci: true
           tags: ${{ matrix.registry.domain }}/${{ matrix.registry.account }}/rockylinux:${{ matrix.version.major }}-ubi-${{ matrix.type }}
 
       - name: Push image
@@ -63,3 +64,5 @@ jobs:
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
+          extra-args: |
+            --format=v2s2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,5 @@ jobs:
           labels: |
             name=rockylinux
             version=${{ matrix.version.major }}-ubi-${{ matrix.type }}
+          oci: true
           tags: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_ACCOUNT }}/rockylinux:${{ matrix.version.major }}-ubi-${{ matrix.type }}


### PR DESCRIPTION
This is a workaround to the issue, that leads from the buildah version 1.23.1, which is part of Ubuntu 22.04 LTS...
containers/buildah issues/4395

Hopefully some time in the future this will work naturally.