### PR TITLE
Temporarily remove ppc64le

### DIFF
--- a/.github/workflows/build-2nd-layer.yml
+++ b/.github/workflows/build-2nd-layer.yml
@@ -16,7 +16,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, ppc64le, s390x'
+            arch: 'amd64, arm64, s390x'
         type:
           - micro
           - init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, ppc64le, s390x'
+            arch: 'amd64, arm64, s390x'
         type:
           - micro
           - init


### PR DESCRIPTION
As ppc64le has still no image in the rockylinux:(8|9) image, this will remove ppc64le in the toolbox images.

This is a workaround and should be reverted as soon as they are available again.