### PR TITLE
Revert "As the ppc64le arch in the source image has not been availabl…

### DIFF
--- a/.github/workflows/build-2nd-layer.yml
+++ b/.github/workflows/build-2nd-layer.yml
@@ -16,7 +16,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, s390x'
+            arch: 'amd64, arm64, ppc64le, s390x'
         type:
           - micro
           - init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - major: 8
             arch: 'amd64, arm64'
           - major: 9
-            arch: 'amd64, arm64, s390x'
+            arch: 'amd64, arm64, ppc64le, s390x'
         type:
           - micro
           - init


### PR DESCRIPTION
…e for months, this temporarily removes the arch in the builds as well as from the registry images (#44)"

This reverts commit 2d0198b6a66a0153bc0a286d71ef767821598fbe.